### PR TITLE
Add order status management and product booking workflow

### DIFF
--- a/src/main/kotlin/com/example/flo/DTO/OrderUpdateDto.kt
+++ b/src/main/kotlin/com/example/flo/DTO/OrderUpdateDto.kt
@@ -1,0 +1,9 @@
+package com.example.flo.DTO
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Data transfer object for updating order status")
+data class OrderUpdateDto(
+    @Schema(description = "Updated order status (NEW, COMPLITED, REJECTED)", example = "COMPLITED")
+    val status: String
+)

--- a/src/main/kotlin/com/example/flo/DTO/ProductDTO.kt
+++ b/src/main/kotlin/com/example/flo/DTO/ProductDTO.kt
@@ -17,6 +17,6 @@ data class ProductDto(
     @Schema(description = "Product price", example = "1000")
     val price: BigDecimal,
 
-    @Schema(description = "Product status (ACTIVE, INACTIVE, SOLD)", example = "ACTIVE")
+    @Schema(description = "Product status (ACTIVE, INACTIVE, SOLD, BOOKED)", example = "ACTIVE")
     val status: String
 )

--- a/src/main/kotlin/com/example/flo/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/flo/config/SecurityConfig.kt
@@ -79,6 +79,7 @@ class SecurityConfig(
                 auth.requestMatchers(HttpMethod.GET, "/api/orders").hasRole("ADMIN")
                 auth.requestMatchers(HttpMethod.GET, "/api/orders/**").permitAll()
                 auth.requestMatchers(HttpMethod.POST, "/api/orders").permitAll()
+                auth.requestMatchers(HttpMethod.PUT, "/api/orders/**").hasRole("ADMIN")
                 auth.requestMatchers(HttpMethod.POST, "/api/categories").hasRole("ADMIN")
                 auth.requestMatchers(HttpMethod.DELETE, "/api/categories/**").hasRole("ADMIN")
                 auth.requestMatchers(HttpMethod.POST, "/api/products").hasRole("ADMIN")

--- a/src/main/kotlin/com/example/flo/controller/OrderController.kt
+++ b/src/main/kotlin/com/example/flo/controller/OrderController.kt
@@ -1,7 +1,9 @@
 package com.example.flo.controller
 
 import com.example.flo.DTO.OrderDto
+import com.example.flo.DTO.OrderUpdateDto
 import com.example.flo.model.Order
+import com.example.flo.model.OrderStatus
 import com.example.flo.service.OrderService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -61,5 +63,25 @@ class OrderController(private val orderService: OrderService) {
     fun getAllOrders(): ResponseEntity<List<Order>> {
         val orders = orderService.getAllOrders()
         return ResponseEntity.ok(orders)
+    }
+
+    @Operation(summary = "Update order status", description = "Update the status of an existing order")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "Order updated successfully",
+            content = [Content(mediaType = "application/json", schema = Schema(implementation = Order::class))]),
+        ApiResponse(responseCode = "400", description = "Invalid input data", content = [Content()]),
+        ApiResponse(responseCode = "404", description = "Order not found", content = [Content()])
+    ])
+    @SecurityRequirement(name = "bearerAuth")
+    @PutMapping("/{id}")
+    fun updateOrderStatus(
+        @Parameter(description = "Order ID", required = true)
+        @PathVariable id: Long,
+        @Parameter(description = "Updated order status", required = true)
+        @RequestBody updateDto: OrderUpdateDto
+    ): ResponseEntity<Order> {
+        val status = OrderStatus.valueOf(updateDto.status.uppercase())
+        val updatedOrder = orderService.updateOrderStatus(id, status)
+        return ResponseEntity.ok(updatedOrder)
     }
 }

--- a/src/main/kotlin/com/example/flo/model/Order.kt
+++ b/src/main/kotlin/com/example/flo/model/Order.kt
@@ -31,17 +31,15 @@ data class Order(
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @Enumerated(EnumType.STRING)
-    val status: OrderStatus = OrderStatus.NEW
+    var status: OrderStatus = OrderStatus.NEW
 )
 
 @Schema(description = "Enum representing different order statuses")
 enum class OrderStatus {
     @Schema(description = "New order that has just been placed")
     NEW,
-    @Schema(description = "Order is being processed")
-    PROCESSING,
-    @Schema(description = "Order has been fulfilled and completed")
-    COMPLETED,
-    @Schema(description = "Order has been cancelled")
-    CANCELLED
+    @Schema(description = "Order has been completed")
+    COMPLITED,
+    @Schema(description = "Order has been rejected")
+    REJECTED
 }

--- a/src/main/kotlin/com/example/flo/model/Product.kt
+++ b/src/main/kotlin/com/example/flo/model/Product.kt
@@ -23,13 +23,13 @@ data class Product(
   val categories: List<Category>,
   val price: BigDecimal,
   @Enumerated(EnumType.STRING)
-  val status: Status,
+  var status: Status,
   @ElementCollection
   val photos: List<String>?
 )
 
 enum class Status {
-  SOLD, ACTIVE, INACTIVE
+  SOLD, ACTIVE, INACTIVE, BOOKED
 }
 
 @Entity


### PR DESCRIPTION
## Summary
- add the COMPLITED and REJECTED order statuses and expose an admin endpoint to update an order status
- mark ordered products as BOOKED and update product status transitions when an order status changes
- secure the order update API for admins and document the new status options in DTOs

## Testing
- ./gradlew test *(fails: unable to download Gradle distribution due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e727cb848323a6f493dba3eb0a44