### PR TITLE
Allow flo frontend origin

### DIFF
--- a/src/main/kotlin/com/example/flo/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/flo/config/SecurityConfig.kt
@@ -54,7 +54,8 @@ class SecurityConfig(
         val configuration = CorsConfiguration()
         configuration.allowedOrigins = listOf(
             "http://localhost:5173",
-            "http://flo-admin-front.151.244.72.126.nip.io"
+            "http://flo-admin-front.151.244.72.126.nip.io",
+            "http://flo-frontend.151.244.72.126.nip.io"
         )
         configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
         configuration.allowedHeaders = listOf("*")


### PR DESCRIPTION
## Summary
- allow requests from http://flo-frontend.151.244.72.126.nip.io in the CORS configuration

## Testing
- `./gradlew test` *(fails: unable to download dependencies from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ea3efef9ac8323aef36f249b138982